### PR TITLE
refactor: replace outdated action that sends notifications to slack

### DIFF
--- a/.github/workflows/python-cd.yml
+++ b/.github/workflows/python-cd.yml
@@ -108,6 +108,7 @@ jobs:
           labels: ${{ steps.meta-migrations.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
 
       - name: Generate tags and image meta
         id: meta
@@ -127,6 +128,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
 
   deploy:
     runs-on: ubuntu-latest
@@ -141,17 +143,42 @@ jobs:
         with:
           ref: ${{ inputs.GIT_REF }}
 
+      - name: Prep deploy details
+        run: |
+          echo "repo-url=https://github.com/${{ github.repository }}" >> $GITHUB_ENV
+          echo "sha-url=https://github.com/${{ github.repository }}/commit/${{ github.sha }}" >> $GITHUB_ENV
+
       - name: Notify Slack Start
-        if: ${{ inputs.SLACK_CHANNEL != '' }}
         id: slack
+        uses: slackapi/slack-github-action@v1.23.0
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: mirta-com/github-action-slack-notify-build@v1.3.6
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOY_BOT_TOKEN }}
         with:
-          channel: ${{ inputs.SLACK_CHANNEL }}
-          status: STARTING
-          color: warning
-          message: <https://github.com/${{ github.repository }}/commit/${{ inputs.GIT_REF }} | ${{ inputs.GIT_REF }}>
+          channel-id: ${{ inputs.SLACK_CHANNEL }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Deployment started - <${{ env.repo-url }} | ${{ github.repository }}>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Job:* <${{ env.sha-url }}/checks | ${{ github.workflow }}>\n*Author:* ${{ github.triggering_actor }}\n*Commit:* <${{ env.sha-url }} | ${{ github.sha }}>\n*Attempt #:* ${{ github.run_attempt }}"
+                  },
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "https://i.postimg.cc/fJWsyZLp/Warning-3.png",
+                    "alt_text": "warning"
+                  }
+                }
+              ]
+            }
 
       - name: Configure ${{ inputs.ENV }} AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -192,25 +219,67 @@ jobs:
             -d "{\"event_type\":\"deploy\", \"client_payload\":{\"env\":\"${{ inputs.ENV }}\"}}"
 
       - name: Notify Slack Success
-        if: ${{ inputs.SLACK_CHANNEL != '' && steps.deploy-script.outcome == 'success' }}
+        if: ${{ steps.deploy-script.outcome == 'success' && inputs.SLACK_CHANNEL != '' }}
+        uses: slackapi/slack-github-action@v1.23.0
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: mirta-com/github-action-slack-notify-build@v1.3.6
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOY_BOT_TOKEN }}
         with:
-          message_id: ${{ steps.slack.outputs.message_id }}
-          channel: ${{ inputs.SLACK_CHANNEL }}
-          status: SUCCESS
-          color: good
-          message: <https://github.com/${{ github.repository }}/commit/${{ inputs.GIT_REF }} | ${{ inputs.GIT_REF }}>
+          channel-id: ${{ inputs.SLACK_CHANNEL }}
+          update-ts: ${{ steps.slack.outputs.ts }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Deployment succeeded - <${{ env.repo-url }} | ${{ github.repository }}>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Job:* <${{ env.sha-url }}/checks | ${{ github.workflow }}>\n*Author:* ${{ github.triggering_actor }}\n*Commit:* <${{ env.sha-url }} | ${{ github.sha }}>\n*Attempt #:* ${{ github.run_attempt }}"
+                  },
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "https://i.postimg.cc/nCdJQ59z/Pass-3.png",
+                    "alt_text": "success"
+                  }
+                }
+              ]
+            }
 
       - name: Notify Slack Fail
         if: ${{ failure() && inputs.SLACK_CHANNEL != '' }}
+        uses: slackapi/slack-github-action@v1.23.0
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: mirta-com/github-action-slack-notify-build@v1.3.6
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOY_BOT_TOKEN }}
         with:
-          message_id: ${{ steps.slack.outputs.message_id }}
-          channel: ${{ inputs.SLACK_CHANNEL }}
-          status: FAILED
-          color: danger
-          message: <https://github.com/${{ github.repository }}/commit/${{ inputs.GIT_REF }} | ${{ inputs.GIT_REF }}>
+          channel-id: ${{ inputs.SLACK_CHANNEL }}
+          update-ts: ${{ steps.slack.outputs.ts }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Deployment failed - <${{ env.repo-url }} | ${{ github.repository }}>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Job:* <${{ env.sha-url }}/checks | ${{ github.workflow }}>\n*Author:* ${{ github.triggering_actor }}\n*Commit:* <${{ env.sha-url }} | ${{ github.sha }}>\n*Attempt #:* ${{ github.run_attempt }}"
+                  },
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "https://i.postimg.cc/qgx0pgk2/Fail-3.png",
+                    "alt_text": "fail"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
I chose to use slackapi/slack-github-action since it looks like the official action and it's still maintained.  
The current implementation in our workflow is more verbose, but it gives us more control on what we want to print, since it references directly slack's new [block kit](https://api.slack.com/block-kit) framework.

⚠️ there's a kind of **breaking change** for which all repos calling this workflow have to replace the channel _name_ with the channel _id_. (it's the only downside of having our repos point directly to main instead of a specific commit or tag)